### PR TITLE
Create one eventset per thread.

### DIFF
--- a/bin/varnishd/cache/cache.h
+++ b/bin/varnishd/cache/cache.h
@@ -260,6 +260,8 @@ struct worker {
 	unsigned		cur_method;
 	unsigned		seen_methods;
 	unsigned		handling;
+
+	int			eventset;
 };
 
 /* Stored object -----------------------------------------------------

--- a/bin/varnishd/cache/cache_vcl.c
+++ b/bin/varnishd/cache/cache_vcl.c
@@ -1102,37 +1102,14 @@ vcl_cli_show(struct cli *cli, const char * const *av, void *priv)
 	}
 }
 
-#define N_EVENTS 4
-static int events[N_EVENTS] = {PAPI_TOT_INS, PAPI_L2_ICM, PAPI_L2_DCM, PAPI_L3_TCM};
-
-static inline int
-create_eventset(void)
-{
-	int eventset = PAPI_NULL;
-	int i;
-
-	AZ(PAPI_create_eventset(&eventset));
-	for (i = 0; i < N_EVENTS; i++) {
-		AZ(PAPI_add_event(eventset, events[i]));
-	}
-
-	return eventset;
-}
-
-static inline void
-destroy_eventset(int eventset)
-{
-	AZ(PAPI_cleanup_eventset(eventset));
-	AZ(PAPI_destroy_eventset(&eventset));
-}
-
 static inline void
 print_values(struct vsl_log *vsl, unsigned method, long long *values)
 {
 	int i;
 	char out[PAPI_MAX_STR_LEN];
+	int events[4] = {PAPI_TOT_INS, PAPI_L2_ICM, PAPI_L2_DCM, PAPI_L3_TCM};
 
-	for (i = 0; i < N_EVENTS; i++) {
+	for (i = 0; i < sizeof(events) / sizeof(events[0]); i++) {
 		PAPI_event_code_to_name(events[i], out);
 		VSLb(vsl, SLT_VCL_perf, "%s,%s,%lld", VCL_Method_Name(method),
 		     out, values[i]);
@@ -1150,8 +1127,8 @@ static void
 vcl_call_method(struct worker *wrk, struct req *req, struct busyobj *bo,
     void *specific, unsigned method, vcl_func_f *func)
 {
-	int eventset;
-	long long values[N_EVENTS];
+	int eventset = wrk->eventset;
+	long long values[4];
 	uintptr_t aws;
 	struct vsl_log *vsl = NULL;
 	struct vrt_ctx ctx;
@@ -1198,11 +1175,9 @@ vcl_call_method(struct worker *wrk, struct req *req, struct busyobj *bo,
 	wrk->seen_methods |= method;
 	AN(vsl);
 	VSLb(vsl, SLT_VCL_call, "%s", VCL_Method_Name(method));
-	eventset = create_eventset();
 	AZ(PAPI_start(eventset));
 	func(&ctx);
 	AZ(PAPI_stop(eventset, values));
-	destroy_eventset(eventset);
 	print_values(ctx.vsl, method, values);
 	VSLb(vsl, SLT_VCL_return, "%s", VCL_Return_Name(wrk->handling));
 	wrk->cur_method |= 1;		// Magic marker


### PR DESCRIPTION
Creating and destroying eventsets introduces signficant lock contention.